### PR TITLE
importcards: add Japanese promo cards page (14 columns) support

### DIFF
--- a/api/management/commands/importcards.py
+++ b/api/management/commands/importcards.py
@@ -459,6 +459,9 @@ class Command(BaseCommand):
 	                        skill_details = clean(tds[-1].string)
 	                        center_skill_name = None
 	                        center_skill_details = None
+	                    elif len(tds) == 14: # promo cards
+	                        skill_name, skill_details = extract_skill(tds[-2])
+	                        center_skill_name, center_skill_details = extract_skill(tds[-1])
 	                    elif len(tds) == 18: # all info specified
 	                        skill_name, skill_details = extract_skill(tds[-2])
 	                        center_skill_name, center_skill_details = extract_skill(tds[-1])


### PR DESCRIPTION
patch for issue #134 
This code doesn't fix "japanese_skill_details" field of existing rows, which should be null, so need to be fixed manually.
```sql
UPDATE api_card SET japanese_skill_details = null WHERE is_promo = 1;
```