### PR TITLE
importcards: add support for Japanese skill names of special cards

### DIFF
--- a/api/management/commands/importcards.py
+++ b/api/management/commands/importcards.py
@@ -454,9 +454,13 @@ class Command(BaseCommand):
 	                        name = clean(name.split('（')[0])
 	                    else:
 	                        version = ''
-	                    if len(tds) == 5: # special card
+	                    if len(tds) == 5: # special cards ( no skill column )
 	                        skill_name = None
 	                        skill_details = clean(tds[-1].string)
+	                        center_skill_name = None
+	                        center_skill_details = None
+	                    elif len(tds) == 7: # special cards ( with skill columns )
+	                        skill_name, skill_details = extract_skill(tds[-2])
 	                        center_skill_name = None
 	                        center_skill_details = None
 	                    elif len(tds) == 14: # promo cards


### PR DESCRIPTION
Sorry, the patch #139 for issue #134 was insufficient. 
Some special cards (e.g. Yazawas ) also had wrong skill names in my testing environment. 
This patch adds support for special cards which have 7 columns in Japanese wiki.