### PR TITLE
Add tooltips to the idol selector

### DIFF
--- a/web/templates/cards.html
+++ b/web/templates/cards.html
@@ -6,7 +6,7 @@
 
 {% block title %}{% if view == 'albumbuilder' %}{% trans 'Album Builder' %}{% else %}{% trans 'Cards Album' %}{% if single %}: {{ single }}{% elif request_get.name %}: {{ request_get.name }}{% endif %}{% endif %}{% endblock %}
 {% block js %}
-<script src="//i.schoolido.lu/static/bower/CuteForm/cuteform.js"></script>
+<script src="/static/bower/CuteForm/cuteform.js"></script>
 <script>
   cuteform($('#id_attribute'), {
     'images': {
@@ -43,6 +43,7 @@
   cuteform($('#id_name'), {
     'modal': 'true',
     'modal-text': 'true',
+    'add-title': 'true',
     'images': {
       {% for idol, str in filters.idols %}
       {% if idol == '' %}'': '//i.schoolido.lu/static/empty.png',{% else %}'{{ idol|escapejs }}': '{% chibiimage idol=idol small=True force_artist='shinylyni' force_first=True %}',{% endif %}


### PR DESCRIPTION
Some people may find it hard to identify which idol each image
belongs to (Especially the N's, who many people don't know as well
as the u's or Aqours girls) This patch adds a tooltip that shows
the idol's name when you hover over the image.

Note this also requires [this patch to CuteForm](https://github.com/db0company/CuteForm/pull/1)